### PR TITLE
Ignoring cython==0.29.31

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
 
             install_requires=requirements.readlines(),
             setup_requires=[
-                'cython',
+                'cython!=0.29.31',
                 'setuptools >= 18.0',
                 'setuptools_scm',
             ],


### PR DESCRIPTION
Related issue:
https://github.com/cython/cython/issues/4927

```
pip install python-pkcs11
```

Results in:
```
pkcs11/_pkcs11.c:45689:20: error: lvalue required as left operand of assignment
    45689 |     CYTHON_ATOMICS = __Pyx_PyObject_IsTrue(o); if (unlikely((CYTHON_ATOMICS == (int)-1) && PyErr_Occurred())) __PYX_ERR(3, 26, __pyx_L2_error)
          |                    ^
    error: command 'gcc' failed with exit status 1
```

Other work-around is to:
```
pip install cython==0.29.30
pip install python-pkcs11
```