### PR TITLE
fix for issue #140 : lack of support for generation of CKK_GENERIC_SECRET key type

### DIFF
--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -658,7 +658,7 @@ class Session(types.Session):
             Attribute.DERIVE: MechanismFlag.DERIVE & capabilities,
         }
 
-        if key_type is KeyType.AES:
+        if key_type not in (KeyType.DES2, KeyType.DES3, KeyType.GOST28147, KeyType.SEED):
             if key_length is None:
                 raise ArgumentsBad("Must provide `key_length'")
 

--- a/pkcs11/defaults.py
+++ b/pkcs11/defaults.py
@@ -26,6 +26,7 @@ DEFAULT_GENERATE_MECHANISMS = {
     KeyType.RSA: Mechanism.RSA_PKCS_KEY_PAIR_GEN,
     KeyType.X9_42_DH: Mechanism.X9_42_DH_KEY_PAIR_GEN,
     KeyType.EC_EDWARDS: Mechanism.EC_EDWARDS_KEY_PAIR_GEN,
+    KeyType.GENERIC_SECRET: Mechanism.GENERIC_SECRET_KEY_GEN,
 }
 """
 Default mechanisms for generating keys.


### PR DESCRIPTION
This commit provides a fix for issue #140.

- Adding a default mechanism for `CKK_GENERIC_SECRET` key type
- Fixing condition for including `CKA_VALUE_LEN` when generating a secret key. It is now skipped only for those algorithms that do not want it.