### PR TITLE
add util imports so examples are usable

### DIFF
--- a/pkcs11/__init__.py
+++ b/pkcs11/__init__.py
@@ -6,6 +6,11 @@ from .constants import *  # noqa: F403
 from .exceptions import *  # noqa: F403
 from .mechanisms import *  # noqa: F403
 from .types import *  # noqa: F403
+from .util import dh # noqa: F403
+from .util import dsa # noqa: F403
+from .util import ec # noqa: F403
+from .util import rsa # noqa: F403
+from .util import x509 # noqa: F403
 
 
 _so = None


### PR DESCRIPTION
Currently, you cant  actually import any of the utils, since they arent brought up to the head __init__.