### PR TITLE
Update dependencies and fix Windows compatibility on Python 3.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+    # Maintain dependencies for PIP
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,13 +5,13 @@
 #    pip-compile dev-requirements.in
 #
 alabaster==0.7.12         # via sphinx
-asn1crypto==1.3.0         # via oscrypto
+asn1crypto==1.5.0         # via oscrypto
 babel==2.8.0              # via sphinx
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 cryptography==3.2         # via -r dev-requirements.in
-cython==0.29.15           # via -r dev-requirements.in
+cython==3.0.9             # via -r dev-requirements.in
 docutils==0.16            # via sphinx
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r dev-requirements.in

--- a/extern/pkcs11.h
+++ b/extern/pkcs11.h
@@ -1,12 +1,11 @@
-/* Copyright (c) OASIS Open 2016. All Rights Reserved./
- * /Distributed under the terms of the OASIS IPR Policy,
- * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
- * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
- * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
- */
-        
-/* Latest version of the specification:
- * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
+/*
+ * PKCS #11 Specification Version 3.1
+ * OASIS Standard
+ * 23 July 2023
+ * Copyright (c) OASIS Open 2023. All Rights Reserved.
+ * Source: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/include/pkcs11-v3.1/
+ * Latest stage of narrative specification: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/pkcs11-spec-v3.1.html
+ * TC IPR Statement: https://www.oasis-open.org/committees/pkcs11/ipr.php 
  */
 
 #ifndef _PKCS11_H_
@@ -29,8 +28,7 @@ extern "C" {
  * convention on packing is that structures should be 1-byte
  * aligned.
  *
- * If you're using Microsoft Developer Studio 5.0 to produce
- * Win32 stuff, this might be done by using the following
+ * If you're using Windows this might be done by using the following
  * preprocessor directive before including pkcs11.h or pkcs11t.h:
  *
  * #pragma pack(push, cryptoki, 1)
@@ -39,13 +37,6 @@ extern "C" {
  * pkcs11.h or pkcs11t.h:
  *
  * #pragma pack(pop, cryptoki)
- *
- * If you're using an earlier version of Microsoft Developer
- * Studio to produce Win16 stuff, this might be done by using
- * the following preprocessor directive before including
- * pkcs11.h or pkcs11t.h:
- *
- * #pragma pack(1)
  *
  * In a UNIX environment, you're on your own for this.  You might
  * not need to do (or be able to do!) anything.
@@ -59,15 +50,9 @@ extern "C" {
  *
  * typedef CK_BYTE CK_PTR CK_BYTE_PTR;
  *
- * If you're using Microsoft Developer Studio 5.0 to produce
- * Win32 stuff, it might be defined by:
+ * If you're using Windows, it might be defined by:
  *
  * #define CK_PTR *
- *
- * If you're using an earlier version of Microsoft Developer
- * Studio to produce Win16 stuff, it might be defined by:
- *
- * #define CK_PTR far *
  *
  * In a typical UNIX environment, it might be defined by:
  *
@@ -83,18 +68,11 @@ extern "C" {
  *   CK_VOID_PTR pReserved
  * );
  *
- * If you're using Microsoft Developer Studio 5.0 to declare a
- * function in a Win32 Cryptoki .dll, it might be defined by:
+ * If you're using Windows to declare a function in a Win32 Cryptoki .dll, 
+ * it might be defined by:
  *
  * #define CK_DECLARE_FUNCTION(returnType, name) \
  *   returnType __declspec(dllimport) name
- *
- * If you're using an earlier version of Microsoft Developer
- * Studio to declare a function in a Win16 Cryptoki .dll, it
- * might be defined by:
- *
- * #define CK_DECLARE_FUNCTION(returnType, name) \
- *   returnType __export _far _pascal name
  *
  * In a UNIX environment, it might be defined by:
  *
@@ -120,18 +98,11 @@ extern "C" {
  * typedef CK_DECLARE_FUNCTION_POINTER(CK_RV, funcPtrType)(args);
  * funcPtrType funcPtr;
  *
- * If you're using Microsoft Developer Studio 5.0 to access
+ * If you're using Windows to access
  * functions in a Win32 Cryptoki .dll, in might be defined by:
  *
  * #define CK_DECLARE_FUNCTION_POINTER(returnType, name) \
  *   returnType __declspec(dllimport) (* name)
- *
- * If you're using an earlier version of Microsoft Developer
- * Studio to access functions in a Win16 Cryptoki .dll, it might
- * be defined by:
- *
- * #define CK_DECLARE_FUNCTION_POINTER(returnType, name) \
- *   returnType __export _far _pascal (* name)
  *
  * In a UNIX environment, it might be defined by:
  *
@@ -153,17 +124,10 @@ extern "C" {
  * typedef CK_CALLBACK_FUNCTION(CK_RV, myCallbackType)(args);
  * myCallbackType myCallback;
  *
- * If you're using Microsoft Developer Studio 5.0 to do Win32
- * Cryptoki development, it might be defined by:
+ * If you're using Windows, it might be defined by:
  *
  * #define CK_CALLBACK_FUNCTION(returnType, name) \
  *   returnType (* name)
- *
- * If you're using an earlier version of Microsoft Developer
- * Studio to do Win16 development, it might be defined by:
- *
- * #define CK_CALLBACK_FUNCTION(returnType, name) \
- *   returnType _far _pascal (* name)
  *
  * In a UNIX environment, it might be defined by:
  *
@@ -240,6 +204,22 @@ extern "C" {
 #define CK_PKCS11_FUNCTION_INFO(name) \
   __PASTE(CK_,name) name;
 
+/* Create the 3.0 Function list */
+struct CK_FUNCTION_LIST_3_0 {
+
+  CK_VERSION    version;  /* Cryptoki version */
+
+/* Pile all the function pointers into the CK_FUNCTION_LIST. */
+/* pkcs11f.h has all the information about the Cryptoki
+ * function prototypes.
+ */
+#include "pkcs11f.h"
+
+};
+
+#define CK_PKCS11_2_0_ONLY 1
+
+/* Continue to define the old CK_FUNCTION_LIST */
 struct CK_FUNCTION_LIST {
 
   CK_VERSION    version;  /* Cryptoki version */
@@ -253,6 +233,7 @@ struct CK_FUNCTION_LIST {
 };
 
 #undef CK_PKCS11_FUNCTION_INFO
+#undef CK_PKCS11_2_0_ONLY
 
 
 #undef __PASTE
@@ -262,4 +243,3 @@ struct CK_FUNCTION_LIST {
 #endif
 
 #endif /* _PKCS11_H_ */
-

--- a/extern/pkcs11f.h
+++ b/extern/pkcs11f.h
@@ -1,12 +1,11 @@
-/* Copyright (c) OASIS Open 2016. All Rights Reserved./
- * /Distributed under the terms of the OASIS IPR Policy,
- * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
- * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
- * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
- */
-        
-/* Latest version of the specification:
- * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
+/*
+ * PKCS #11 Specification Version 3.1
+ * OASIS Standard
+ * 23 July 2023
+ * Copyright (c) OASIS Open 2023. All Rights Reserved.
+ * Source: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/include/pkcs11-v3.1/
+ * Latest stage of narrative specification: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/pkcs11-spec-v3.1.html
+ * TC IPR Statement: https://www.oasis-open.org/committees/pkcs11/ipr.php 
  */
 
 /* This header file contains pretty much everything about all the
@@ -937,3 +936,260 @@ CK_PKCS11_FUNCTION_INFO(C_WaitForSlotEvent)
 );
 #endif
 
+#ifndef CK_PKCS11_2_0_ONLY
+/* C_GetInterfaceList returns all the interfaces supported by the module*/
+CK_PKCS11_FUNCTION_INFO(C_GetInterfaceList)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_INTERFACE_PTR  pInterfacesList,  /* returned interfaces */
+  CK_ULONG_PTR      pulCount          /* number of interfaces returned */
+);
+#endif
+
+/* C_GetInterface returns a specific interface from the module. */
+CK_PKCS11_FUNCTION_INFO(C_GetInterface)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_UTF8CHAR_PTR       pInterfaceName, /* name of the interface */
+  CK_VERSION_PTR        pVersion,       /* version of the interface */
+  CK_INTERFACE_PTR_PTR  ppInterface,    /* returned interface */
+  CK_FLAGS 		flags           /* flags controlling the semantics
+                                         * of the interface */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_LoginUser)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_USER_TYPE      userType,  /* the user type */
+  CK_UTF8CHAR_PTR   pPin,      /* the user's PIN */
+  CK_ULONG          ulPinLen,  /* the length of the PIN */
+  CK_UTF8CHAR_PTR   pUsername, /* the user's name */
+  CK_ULONG          ulUsernameLen /*the length of the user's name */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_SessionCancel)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_FLAGS          flags      /* flags control which sessions are cancelled */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_MessageEncryptInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,  /* the encryption mechanism */
+  CK_OBJECT_HANDLE  hKey         /* handle of encryption key */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_EncryptMessage)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen,      /* length of message specific parameter */
+  CK_BYTE_PTR pAssociatedData,  /* AEAD Associated data */
+  CK_ULONG ulAssociatedDataLen, /* AEAD Associated data length */
+  CK_BYTE_PTR pPlaintext,       /* plain text  */
+  CK_ULONG ulPlaintextLen,      /* plain text length */
+  CK_BYTE_PTR pCiphertext,      /* gets cipher text */
+  CK_ULONG_PTR pulCiphertextLen /* gets cipher text length */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_EncryptMessageBegin)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen,      /* length of message specific parameter */
+  CK_BYTE_PTR pAssociatedData,  /* AEAD Associated data */
+  CK_ULONG ulAssociatedDataLen  /* AEAD Associated data length */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_EncryptMessageNext)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,        /* the session's handle */
+  CK_VOID_PTR pParameter,            /* message specific parameter */
+  CK_ULONG ulParameterLen,           /* length of message specific parameter */
+  CK_BYTE_PTR pPlaintextPart,        /* plain text */
+  CK_ULONG ulPlaintextPartLen,       /* plain text length */
+  CK_BYTE_PTR pCiphertextPart,       /* gets cipher text */
+  CK_ULONG_PTR pulCiphertextPartLen, /* gets cipher text length */
+  CK_FLAGS flags                     /* multi mode flag */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_MessageEncryptFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession        /* the session's handle */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_MessageDecryptInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,  /* the decryption mechanism */
+  CK_OBJECT_HANDLE  hKey         /* handle of decryption key */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_DecryptMessage)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen,      /* length of message specific parameter */
+  CK_BYTE_PTR pAssociatedData,  /* AEAD Associated data */
+  CK_ULONG ulAssociatedDataLen, /* AEAD Associated data length */
+  CK_BYTE_PTR pCiphertext,      /* cipher text */
+  CK_ULONG ulCiphertextLen,     /* cipher text length */
+  CK_BYTE_PTR pPlaintext,       /* gets plain text */
+  CK_ULONG_PTR pulPlaintextLen  /* gets plain text length */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_DecryptMessageBegin)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen,      /* length of message specific parameter */
+  CK_BYTE_PTR pAssociatedData,  /* AEAD Associated data */
+  CK_ULONG ulAssociatedDataLen  /* AEAD Associated data length */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_DecryptMessageNext)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,        /* the session's handle */
+  CK_VOID_PTR pParameter,            /* message specific parameter */
+  CK_ULONG ulParameterLen,           /* length of message specific parameter */
+  CK_BYTE_PTR pCiphertextPart,       /* cipher text */
+  CK_ULONG ulCiphertextPartLen,      /* cipher text length */
+  CK_BYTE_PTR pPlaintextPart,        /* gets plain text */
+  CK_ULONG_PTR pulPlaintextPartLen,  /* gets plain text length */
+  CK_FLAGS flags                     /* multi mode flag */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_MessageDecryptFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession        /* the session's handle */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_MessageSignInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,  /* the signing mechanism */
+  CK_OBJECT_HANDLE  hKey         /* handle of signing key */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_SignMessage)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen,      /* length of message specific parameter */
+  CK_BYTE_PTR pData,            /* data to sign */
+  CK_ULONG ulDataLen,           /* data to sign length */
+  CK_BYTE_PTR pSignature,       /* gets signature */
+  CK_ULONG_PTR pulSignatureLen  /* gets signature length */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_SignMessageBegin)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen      /* length of message specific parameter */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_SignMessageNext)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen,      /* length of message specific parameter */
+  CK_BYTE_PTR pData,            /* data to sign */
+  CK_ULONG ulDataLen,           /* data to sign length */
+  CK_BYTE_PTR pSignature,       /* gets signature */
+  CK_ULONG_PTR pulSignatureLen  /* gets signature length */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_MessageSignFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession        /* the session's handle */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_MessageVerifyInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,  /* the signing mechanism */
+  CK_OBJECT_HANDLE  hKey         /* handle of signing key */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_VerifyMessage)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen,      /* length of message specific parameter */
+  CK_BYTE_PTR pData,            /* data to sign */
+  CK_ULONG ulDataLen,           /* data to sign length */
+  CK_BYTE_PTR pSignature,       /* signature */
+  CK_ULONG ulSignatureLen       /* signature length */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_VerifyMessageBegin)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen      /* length of message specific parameter */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_VerifyMessageNext)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_VOID_PTR pParameter,       /* message specific parameter */
+  CK_ULONG ulParameterLen,      /* length of message specific parameter */
+  CK_BYTE_PTR pData,            /* data to sign */
+  CK_ULONG ulDataLen,           /* data to sign length */
+  CK_BYTE_PTR pSignature,       /* signature */
+  CK_ULONG ulSignatureLen       /* signature length */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_MessageVerifyFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession        /* the session's handle */
+);
+#endif
+
+#endif /* CK_PKCS11_2_0_ONLY */

--- a/extern/pkcs11t.h
+++ b/extern/pkcs11t.h
@@ -1,12 +1,11 @@
-/* Copyright (c) OASIS Open 2016. All Rights Reserved./
- * /Distributed under the terms of the OASIS IPR Policy,
- * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
- * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
- * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
- */
-
-/* Latest version of the specification:
- * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
+/*
+ * PKCS #11 Specification Version 3.1
+ * OASIS Standard
+ * 23 July 2023
+ * Copyright (c) OASIS Open 2023. All Rights Reserved.
+ * Source: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/include/pkcs11-v3.1/
+ * Latest stage of narrative specification: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/pkcs11-spec-v3.1.html
+ * TC IPR Statement: https://www.oasis-open.org/committees/pkcs11/ipr.php 
  */
 
 /* See top of pkcs11.h for information about the macros that
@@ -17,8 +16,8 @@
 #ifndef _PKCS11T_H_
 #define _PKCS11T_H_ 1
 
-#define CRYPTOKI_VERSION_MAJOR          2
-#define CRYPTOKI_VERSION_MINOR          40
+#define CRYPTOKI_VERSION_MAJOR          3
+#define CRYPTOKI_VERSION_MINOR          1
 #define CRYPTOKI_VERSION_AMENDMENT      0
 
 #define CK_TRUE         1
@@ -317,10 +316,22 @@ typedef CK_ULONG          CK_OBJECT_CLASS;
 #define CKO_DOMAIN_PARAMETERS 0x00000006UL
 #define CKO_MECHANISM         0x00000007UL
 #define CKO_OTP_KEY           0x00000008UL
+#define CKO_PROFILE           0x00000009UL 
 
 #define CKO_VENDOR_DEFINED    0x80000000UL
 
 typedef CK_OBJECT_CLASS CK_PTR CK_OBJECT_CLASS_PTR;
+
+/* Profile ID's */
+#define CKP_INVALID_ID                0x00000000UL
+#define CKP_BASELINE_PROVIDER         0x00000001UL
+#define CKP_EXTENDED_PROVIDER         0x00000002UL
+#define CKP_AUTHENTICATION_TOKEN      0x00000003UL
+#define CKP_PUBLIC_CERTIFICATES_TOKEN 0x00000004UL
+#define CKP_COMPLETE_PROVIDER         0x00000005UL
+#define CKP_HKDF_TLS_TOKEN            0x00000006UL
+#define CKP_VENDOR_DEFINED            0x80000000UL
+
 
 /* CK_HW_FEATURE_TYPE is a value that identifies the hardware feature type
  * of an object with CK_OBJECT_CLASS equal to CKO_HW_FEATURE.
@@ -369,6 +380,8 @@ typedef CK_ULONG          CK_KEY_TYPE;
 #define CKK_CAMELLIA            0x00000025UL
 #define CKK_ARIA                0x00000026UL
 
+/* the following definitions were added in the 2.30 header file,
+ * but never defined in the spec. */
 #define CKK_MD5_HMAC            0x00000027UL
 #define CKK_SHA_1_HMAC          0x00000028UL
 #define CKK_RIPEMD128_HMAC      0x00000029UL
@@ -382,11 +395,27 @@ typedef CK_ULONG          CK_KEY_TYPE;
 #define CKK_GOSTR3410           0x00000030UL
 #define CKK_GOSTR3411           0x00000031UL
 #define CKK_GOST28147           0x00000032UL
-
-/* from version 3.0 */
+#define CKK_CHACHA20            0x00000033UL
+#define CKK_POLY1305            0x00000034UL
+#define CKK_AES_XTS             0x00000035UL
+#define CKK_SHA3_224_HMAC       0x00000036UL
+#define CKK_SHA3_256_HMAC       0x00000037UL
+#define CKK_SHA3_384_HMAC       0x00000038UL
+#define CKK_SHA3_512_HMAC       0x00000039UL
+#define CKK_BLAKE2B_160_HMAC    0x0000003aUL
+#define CKK_BLAKE2B_256_HMAC    0x0000003bUL
+#define CKK_BLAKE2B_384_HMAC    0x0000003cUL
+#define CKK_BLAKE2B_512_HMAC    0x0000003dUL
+#define CKK_SALSA20             0x0000003eUL
+#define CKK_X2RATCHET           0x0000003fUL
 #define CKK_EC_EDWARDS          0x00000040UL
+#define CKK_EC_MONTGOMERY       0x00000041UL
+#define CKK_HKDF                0x00000042UL
 
-
+#define CKK_SHA512_224_HMAC     0x00000043UL
+#define CKK_SHA512_256_HMAC     0x00000044UL
+#define CKK_SHA512_T_HMAC       0x00000045UL
+#define CKK_HSS                 0x00000046UL
 
 #define CKK_VENDOR_DEFINED      0x80000000UL
 
@@ -442,6 +471,7 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_TOKEN              0x00000001UL
 #define CKA_PRIVATE            0x00000002UL
 #define CKA_LABEL              0x00000003UL
+#define CKA_UNIQUE_ID          0x00000004UL
 #define CKA_APPLICATION        0x00000010UL
 #define CKA_VALUE              0x00000011UL
 #define CKA_OBJECT_ID          0x00000012UL
@@ -455,9 +485,9 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_CERTIFICATE_CATEGORY        0x00000087UL
 #define CKA_JAVA_MIDP_SECURITY_DOMAIN   0x00000088UL
 #define CKA_URL                         0x00000089UL
-#define CKA_HASH_OF_SUBJECT_PUBLIC_KEY  0x0000008AUL
-#define CKA_HASH_OF_ISSUER_PUBLIC_KEY   0x0000008BUL
-#define CKA_NAME_HASH_ALGORITHM         0x0000008CUL
+#define CKA_HASH_OF_SUBJECT_PUBLIC_KEY  0x0000008aUL
+#define CKA_HASH_OF_ISSUER_PUBLIC_KEY   0x0000008bUL
+#define CKA_NAME_HASH_ALGORITHM         0x0000008cUL
 #define CKA_CHECK_VALUE                 0x00000090UL
 
 #define CKA_KEY_TYPE           0x00000100UL
@@ -470,9 +500,9 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_UNWRAP             0x00000107UL
 #define CKA_SIGN               0x00000108UL
 #define CKA_SIGN_RECOVER       0x00000109UL
-#define CKA_VERIFY             0x0000010AUL
-#define CKA_VERIFY_RECOVER     0x0000010BUL
-#define CKA_DERIVE             0x0000010CUL
+#define CKA_VERIFY             0x0000010aUL
+#define CKA_VERIFY_RECOVER     0x0000010bUL
+#define CKA_DERIVE             0x0000010cUL
 #define CKA_START_DATE         0x00000110UL
 #define CKA_END_DATE           0x00000111UL
 #define CKA_MODULUS            0x00000120UL
@@ -529,12 +559,12 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_OTP_TIME_REQUIREMENT      0x00000225UL
 #define CKA_OTP_COUNTER_REQUIREMENT   0x00000226UL
 #define CKA_OTP_PIN_REQUIREMENT       0x00000227UL
-#define CKA_OTP_COUNTER               0x0000022EUL
-#define CKA_OTP_TIME                  0x0000022FUL
-#define CKA_OTP_USER_IDENTIFIER       0x0000022AUL
-#define CKA_OTP_SERVICE_IDENTIFIER    0x0000022BUL
-#define CKA_OTP_SERVICE_LOGO          0x0000022CUL
-#define CKA_OTP_SERVICE_LOGO_TYPE     0x0000022DUL
+#define CKA_OTP_COUNTER               0x0000022eUL
+#define CKA_OTP_TIME                  0x0000022fUL
+#define CKA_OTP_USER_IDENTIFIER       0x0000022aUL
+#define CKA_OTP_SERVICE_IDENTIFIER    0x0000022bUL
+#define CKA_OTP_SERVICE_LOGO          0x0000022cUL
+#define CKA_OTP_SERVICE_LOGO_TYPE     0x0000022dUL
 
 #define CKA_GOSTR3410_PARAMS            0x00000250UL
 #define CKA_GOSTR3411_PARAMS            0x00000251UL
@@ -559,6 +589,32 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_DEFAULT_CMS_ATTRIBUTES      0x00000502UL
 #define CKA_SUPPORTED_CMS_ATTRIBUTES    0x00000503UL
 #define CKA_ALLOWED_MECHANISMS          (CKF_ARRAY_ATTRIBUTE|0x00000600UL)
+#define CKA_PROFILE_ID                  0x00000601UL
+
+#define CKA_X2RATCHET_BAG               0x00000602UL
+#define CKA_X2RATCHET_BAGSIZE           0x00000603UL
+#define CKA_X2RATCHET_BOBS1STMSG        0x00000604UL
+#define CKA_X2RATCHET_CKR               0x00000605UL
+#define CKA_X2RATCHET_CKS               0x00000606UL
+#define CKA_X2RATCHET_DHP               0x00000607UL
+#define CKA_X2RATCHET_DHR               0x00000608UL
+#define CKA_X2RATCHET_DHS               0x00000609UL
+#define CKA_X2RATCHET_HKR               0x0000060aUL
+#define CKA_X2RATCHET_HKS               0x0000060bUL
+#define CKA_X2RATCHET_ISALICE           0x0000060cUL
+#define CKA_X2RATCHET_NHKR              0x0000060dUL
+#define CKA_X2RATCHET_NHKS              0x0000060eUL
+#define CKA_X2RATCHET_NR                0x0000060fUL
+#define CKA_X2RATCHET_NS                0x00000610UL
+#define CKA_X2RATCHET_PNS               0x00000611UL
+#define CKA_X2RATCHET_RK                0x00000612UL
+/* HSS */
+#define CKA_HSS_LEVELS                  0x00000617UL
+#define CKA_HSS_LMS_TYPE                0x00000618UL
+#define CKA_HSS_LMOTS_TYPE              0x00000619UL
+#define CKA_HSS_LMS_TYPES               0x0000061aUL
+#define CKA_HSS_LMOTS_TYPES             0x0000061bUL
+#define CKA_HSS_KEYS_REMAINING          0x0000061cUL
 
 #define CKA_VENDOR_DEFINED              0x80000000UL
 
@@ -600,11 +656,11 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_RIPEMD160_RSA_PKCS         0x00000008UL
 #define CKM_RSA_PKCS_OAEP              0x00000009UL
 
-#define CKM_RSA_X9_31_KEY_PAIR_GEN     0x0000000AUL
-#define CKM_RSA_X9_31                  0x0000000BUL
-#define CKM_SHA1_RSA_X9_31             0x0000000CUL
-#define CKM_RSA_PKCS_PSS               0x0000000DUL
-#define CKM_SHA1_RSA_PKCS_PSS          0x0000000EUL
+#define CKM_RSA_X9_31_KEY_PAIR_GEN     0x0000000aUL
+#define CKM_RSA_X9_31                  0x0000000bUL
+#define CKM_SHA1_RSA_X9_31             0x0000000cUL
+#define CKM_RSA_PKCS_PSS               0x0000000dUL
+#define CKM_SHA1_RSA_PKCS_PSS          0x0000000eUL
 
 #define CKM_DSA_KEY_PAIR_GEN           0x00000010UL
 #define CKM_DSA                        0x00000011UL
@@ -613,6 +669,10 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_DSA_SHA256                 0x00000014UL
 #define CKM_DSA_SHA384                 0x00000015UL
 #define CKM_DSA_SHA512                 0x00000016UL
+#define CKM_DSA_SHA3_224               0x00000018UL
+#define CKM_DSA_SHA3_256               0x00000019UL
+#define CKM_DSA_SHA3_384               0x0000001aUL
+#define CKM_DSA_SHA3_512               0x0000001bUL
 
 #define CKM_DH_PKCS_KEY_PAIR_GEN       0x00000020UL
 #define CKM_DH_PKCS_DERIVE             0x00000021UL
@@ -634,17 +694,26 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 
 #define CKM_SHA512_224                 0x00000048UL
 #define CKM_SHA512_224_HMAC            0x00000049UL
-#define CKM_SHA512_224_HMAC_GENERAL    0x0000004AUL
-#define CKM_SHA512_224_KEY_DERIVATION  0x0000004BUL
-#define CKM_SHA512_256                 0x0000004CUL
-#define CKM_SHA512_256_HMAC            0x0000004DUL
-#define CKM_SHA512_256_HMAC_GENERAL    0x0000004EUL
-#define CKM_SHA512_256_KEY_DERIVATION  0x0000004FUL
+#define CKM_SHA512_224_HMAC_GENERAL    0x0000004aUL
+#define CKM_SHA512_224_KEY_DERIVATION  0x0000004bUL
+#define CKM_SHA512_256                 0x0000004cUL
+#define CKM_SHA512_256_HMAC            0x0000004dUL
+#define CKM_SHA512_256_HMAC_GENERAL    0x0000004eUL
+#define CKM_SHA512_256_KEY_DERIVATION  0x0000004fUL
 
 #define CKM_SHA512_T                   0x00000050UL
 #define CKM_SHA512_T_HMAC              0x00000051UL
 #define CKM_SHA512_T_HMAC_GENERAL      0x00000052UL
 #define CKM_SHA512_T_KEY_DERIVATION    0x00000053UL
+
+#define CKM_SHA3_256_RSA_PKCS          0x00000060UL
+#define CKM_SHA3_384_RSA_PKCS          0x00000061UL
+#define CKM_SHA3_512_RSA_PKCS          0x00000062UL
+#define CKM_SHA3_256_RSA_PKCS_PSS      0x00000063UL
+#define CKM_SHA3_384_RSA_PKCS_PSS      0x00000064UL
+#define CKM_SHA3_512_RSA_PKCS_PSS      0x00000065UL
+#define CKM_SHA3_224_RSA_PKCS          0x00000066UL
+#define CKM_SHA3_224_RSA_PKCS_PSS      0x00000067UL
 
 #define CKM_RC2_KEY_GEN                0x00000100UL
 #define CKM_RC2_ECB                    0x00000101UL
@@ -724,8 +793,26 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_SECURID                    0x00000282UL
 #define CKM_HOTP_KEY_GEN               0x00000290UL
 #define CKM_HOTP                       0x00000291UL
-#define CKM_ACTI                       0x000002A0UL
-#define CKM_ACTI_KEY_GEN               0x000002A1UL
+#define CKM_ACTI                       0x000002a0UL
+#define CKM_ACTI_KEY_GEN               0x000002a1UL
+
+#define CKM_SHA3_256                   0x000002b0UL
+#define CKM_SHA3_256_HMAC              0x000002b1UL
+#define CKM_SHA3_256_HMAC_GENERAL      0x000002b2UL
+#define CKM_SHA3_256_KEY_GEN           0x000002b3UL
+#define CKM_SHA3_224                   0x000002b5UL
+#define CKM_SHA3_224_HMAC              0x000002b6UL
+#define CKM_SHA3_224_HMAC_GENERAL      0x000002b7UL
+#define CKM_SHA3_224_KEY_GEN           0x000002b8UL
+#define CKM_SHA3_384                   0x000002c0UL
+#define CKM_SHA3_384_HMAC              0x000002c1UL
+#define CKM_SHA3_384_HMAC_GENERAL      0x000002c2UL
+#define CKM_SHA3_384_KEY_GEN           0x000002c3UL
+#define CKM_SHA3_512                   0x000002d0UL
+#define CKM_SHA3_512_HMAC              0x000002d1UL
+#define CKM_SHA3_512_HMAC_GENERAL      0x000002d2UL
+#define CKM_SHA3_512_KEY_GEN           0x000002d3UL
+
 
 #define CKM_CAST_KEY_GEN               0x00000300UL
 #define CKM_CAST_ECB                   0x00000301UL
@@ -792,43 +879,55 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_SHA384_KEY_DERIVATION      0x00000394UL
 #define CKM_SHA512_KEY_DERIVATION      0x00000395UL
 #define CKM_SHA224_KEY_DERIVATION      0x00000396UL
+#define CKM_SHA3_256_KEY_DERIVATION    0x00000397UL
+#define CKM_SHA3_224_KEY_DERIVATION    0x00000398UL
+#define CKM_SHA3_384_KEY_DERIVATION    0x00000399UL
+#define CKM_SHA3_512_KEY_DERIVATION    0x0000039aUL
+#define CKM_SHAKE_128_KEY_DERIVATION   0x0000039bUL
+#define CKM_SHAKE_256_KEY_DERIVATION   0x0000039cUL
+#define CKM_SHA3_256_KEY_DERIVE  CKM_SHA3_256_KEY_DERIVATION
+#define CKM_SHA3_224_KEY_DERIVE  CKM_SHA3_224_KEY_DERIVATION
+#define CKM_SHA3_384_KEY_DERIVE  CKM_SHA3_384_KEY_DERIVATION
+#define CKM_SHA3_512_KEY_DERIVE  CKM_SHA3_512_KEY_DERIVATION
+#define CKM_SHAKE_128_KEY_DERIVE CKM_SHAKE_128_KEY_DERIVATION
+#define CKM_SHAKE_256_KEY_DERIVE CKM_SHAKE_256_KEY_DERIVATION
 
-#define CKM_PBE_MD2_DES_CBC            0x000003A0UL
-#define CKM_PBE_MD5_DES_CBC            0x000003A1UL
-#define CKM_PBE_MD5_CAST_CBC           0x000003A2UL
-#define CKM_PBE_MD5_CAST3_CBC          0x000003A3UL
-#define CKM_PBE_MD5_CAST5_CBC          0x000003A4UL /* Deprecated */
-#define CKM_PBE_MD5_CAST128_CBC        0x000003A4UL
-#define CKM_PBE_SHA1_CAST5_CBC         0x000003A5UL /* Deprecated */
-#define CKM_PBE_SHA1_CAST128_CBC       0x000003A5UL
-#define CKM_PBE_SHA1_RC4_128           0x000003A6UL
-#define CKM_PBE_SHA1_RC4_40            0x000003A7UL
-#define CKM_PBE_SHA1_DES3_EDE_CBC      0x000003A8UL
-#define CKM_PBE_SHA1_DES2_EDE_CBC      0x000003A9UL
-#define CKM_PBE_SHA1_RC2_128_CBC       0x000003AAUL
-#define CKM_PBE_SHA1_RC2_40_CBC        0x000003ABUL
+#define CKM_PBE_MD2_DES_CBC            0x000003a0UL
+#define CKM_PBE_MD5_DES_CBC            0x000003a1UL
+#define CKM_PBE_MD5_CAST_CBC           0x000003a2UL
+#define CKM_PBE_MD5_CAST3_CBC          0x000003a3UL
+#define CKM_PBE_MD5_CAST5_CBC          0x000003a4UL /* Deprecated */
+#define CKM_PBE_MD5_CAST128_CBC        0x000003a4UL
+#define CKM_PBE_SHA1_CAST5_CBC         0x000003a5UL /* Deprecated */
+#define CKM_PBE_SHA1_CAST128_CBC       0x000003a5UL
+#define CKM_PBE_SHA1_RC4_128           0x000003a6UL
+#define CKM_PBE_SHA1_RC4_40            0x000003a7UL
+#define CKM_PBE_SHA1_DES3_EDE_CBC      0x000003a8UL
+#define CKM_PBE_SHA1_DES2_EDE_CBC      0x000003a9UL
+#define CKM_PBE_SHA1_RC2_128_CBC       0x000003aaUL
+#define CKM_PBE_SHA1_RC2_40_CBC        0x000003abUL
 
-#define CKM_PKCS5_PBKD2                0x000003B0UL
+#define CKM_PKCS5_PBKD2                0x000003b0UL
 
-#define CKM_PBA_SHA1_WITH_SHA1_HMAC    0x000003C0UL
+#define CKM_PBA_SHA1_WITH_SHA1_HMAC    0x000003c0UL
 
-#define CKM_WTLS_PRE_MASTER_KEY_GEN         0x000003D0UL
-#define CKM_WTLS_MASTER_KEY_DERIVE          0x000003D1UL
-#define CKM_WTLS_MASTER_KEY_DERIVE_DH_ECC   0x000003D2UL
-#define CKM_WTLS_PRF                        0x000003D3UL
-#define CKM_WTLS_SERVER_KEY_AND_MAC_DERIVE  0x000003D4UL
-#define CKM_WTLS_CLIENT_KEY_AND_MAC_DERIVE  0x000003D5UL
+#define CKM_WTLS_PRE_MASTER_KEY_GEN         0x000003d0UL
+#define CKM_WTLS_MASTER_KEY_DERIVE          0x000003d1UL
+#define CKM_WTLS_MASTER_KEY_DERIVE_DH_ECC   0x000003d2UL
+#define CKM_WTLS_PRF                        0x000003d3UL
+#define CKM_WTLS_SERVER_KEY_AND_MAC_DERIVE  0x000003d4UL
+#define CKM_WTLS_CLIENT_KEY_AND_MAC_DERIVE  0x000003d5UL
 
-#define CKM_TLS10_MAC_SERVER                0x000003D6UL
-#define CKM_TLS10_MAC_CLIENT                0x000003D7UL
-#define CKM_TLS12_MAC                       0x000003D8UL
-#define CKM_TLS12_KDF                       0x000003D9UL
-#define CKM_TLS12_MASTER_KEY_DERIVE         0x000003E0UL
-#define CKM_TLS12_KEY_AND_MAC_DERIVE        0x000003E1UL
-#define CKM_TLS12_MASTER_KEY_DERIVE_DH      0x000003E2UL
-#define CKM_TLS12_KEY_SAFE_DERIVE           0x000003E3UL
-#define CKM_TLS_MAC                         0x000003E4UL
-#define CKM_TLS_KDF                         0x000003E5UL
+#define CKM_TLS10_MAC_SERVER                0x000003d6UL
+#define CKM_TLS10_MAC_CLIENT                0x000003d7UL
+#define CKM_TLS12_MAC                       0x000003d8UL
+#define CKM_TLS12_KDF                       0x000003d9UL
+#define CKM_TLS12_MASTER_KEY_DERIVE         0x000003e0UL
+#define CKM_TLS12_KEY_AND_MAC_DERIVE        0x000003e1UL
+#define CKM_TLS12_MASTER_KEY_DERIVE_DH      0x000003e2UL
+#define CKM_TLS12_KEY_SAFE_DERIVE           0x000003e3UL
+#define CKM_TLS_MAC                         0x000003e4UL
+#define CKM_TLS_KDF                         0x000003e5UL
 
 #define CKM_KEY_WRAP_LYNKS             0x00000400UL
 #define CKM_KEY_WRAP_SET_OAEP          0x00000401UL
@@ -898,6 +997,7 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_ECDSA_SHA256               0x00001044UL
 #define CKM_ECDSA_SHA384               0x00001045UL
 #define CKM_ECDSA_SHA512               0x00001046UL
+#define CKM_EC_KEY_PAIR_GEN_W_EXTRA_BITS 0x0000140bUL
 
 #define CKM_ECDH1_DERIVE               0x00001050UL
 #define CKM_ECDH1_COFACTOR_DERIVE      0x00001051UL
@@ -914,6 +1014,8 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_JUNIPER_WRAP               0x00001065UL
 #define CKM_FASTHASH                   0x00001070UL
 
+#define CKM_AES_XTS                    0x00001071UL
+#define CKM_AES_XTS_KEY_GEN            0x00001072UL
 #define CKM_AES_KEY_GEN                0x00001080UL
 #define CKM_AES_ECB                    0x00001081UL
 #define CKM_AES_CBC                    0x00001082UL
@@ -924,12 +1026,12 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_AES_GCM                    0x00001087UL
 #define CKM_AES_CCM                    0x00001088UL
 #define CKM_AES_CTS                    0x00001089UL
-#define CKM_AES_CMAC                   0x0000108AUL
-#define CKM_AES_CMAC_GENERAL           0x0000108BUL
+#define CKM_AES_CMAC                   0x0000108aUL
+#define CKM_AES_CMAC_GENERAL           0x0000108bUL
 
-#define CKM_AES_XCBC_MAC               0x0000108CUL
-#define CKM_AES_XCBC_MAC_96            0x0000108DUL
-#define CKM_AES_GMAC                   0x0000108EUL
+#define CKM_AES_XCBC_MAC               0x0000108cUL
+#define CKM_AES_XCBC_MAC_96            0x0000108dUL
+#define CKM_AES_GMAC                   0x0000108eUL
 
 #define CKM_BLOWFISH_KEY_GEN           0x00001090UL
 #define CKM_BLOWFISH_CBC               0x00001091UL
@@ -957,12 +1059,17 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_GOST28147                  0x00001222UL
 #define CKM_GOST28147_MAC              0x00001223UL
 #define CKM_GOST28147_KEY_WRAP         0x00001224UL
-
+#define CKM_CHACHA20_KEY_GEN           0x00001225UL
+#define CKM_CHACHA20                   0x00001226UL
+#define CKM_POLY1305_KEY_GEN           0x00001227UL
+#define CKM_POLY1305                   0x00001228UL
 #define CKM_DSA_PARAMETER_GEN          0x00002000UL
 #define CKM_DH_PKCS_PARAMETER_GEN      0x00002001UL
 #define CKM_X9_42_DH_PARAMETER_GEN     0x00002002UL
-#define CKM_DSA_PROBABLISTIC_PARAMETER_GEN    0x00002003UL
+#define CKM_DSA_PROBABILISTIC_PARAMETER_GEN 0x00002003UL
+#define CKM_DSA_PROBABLISTIC_PARAMETER_GEN CKM_DSA_PROBABILISTIC_PARAMETER_GEN
 #define CKM_DSA_SHAWE_TAYLOR_PARAMETER_GEN    0x00002004UL
+#define CKM_DSA_FIPS_G_GEN               0x00002005UL
 
 #define CKM_AES_OFB                    0x00002104UL
 #define CKM_AES_CFB64                  0x00002105UL
@@ -972,13 +1079,74 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_AES_CFB1                   0x00002108UL
 #define CKM_AES_KEY_WRAP               0x00002109UL     /* WAS: 0x00001090 */
 #define CKM_AES_KEY_WRAP_PAD           0x0000210AUL     /* WAS: 0x00001091 */
+#define CKM_AES_KEY_WRAP_KWP           0x0000210BUL
+#define CKM_AES_KEY_WRAP_PKCS7         0x0000210CUL
 
 #define CKM_RSA_PKCS_TPM_1_1           0x00004001UL
 #define CKM_RSA_PKCS_OAEP_TPM_1_1      0x00004002UL
 
-/* from version 3.0 */
-#define CKM_EC_EDWARDS_KEY_PAIR_GEN	   0x00001055UL
+#define CKM_SHA_1_KEY_GEN              0x00004003UL
+#define CKM_SHA224_KEY_GEN             0x00004004UL
+#define CKM_SHA256_KEY_GEN             0x00004005UL
+#define CKM_SHA384_KEY_GEN             0x00004006UL
+#define CKM_SHA512_KEY_GEN             0x00004007UL
+#define CKM_SHA512_224_KEY_GEN         0x00004008UL
+#define CKM_SHA512_256_KEY_GEN         0x00004009UL
+#define CKM_SHA512_T_KEY_GEN           0x0000400aUL
+#define CKM_NULL                       0x0000400bUL
+#define CKM_BLAKE2B_160                0x0000400cUL
+#define CKM_BLAKE2B_160_HMAC           0x0000400dUL
+#define CKM_BLAKE2B_160_HMAC_GENERAL   0x0000400eUL
+#define CKM_BLAKE2B_160_KEY_DERIVE     0x0000400fUL
+#define CKM_BLAKE2B_160_KEY_GEN        0x00004010UL
+#define CKM_BLAKE2B_256                0x00004011UL
+#define CKM_BLAKE2B_256_HMAC           0x00004012UL
+#define CKM_BLAKE2B_256_HMAC_GENERAL   0x00004013UL
+#define CKM_BLAKE2B_256_KEY_DERIVE     0x00004014UL
+#define CKM_BLAKE2B_256_KEY_GEN        0x00004015UL
+#define CKM_BLAKE2B_384                0x00004016UL
+#define CKM_BLAKE2B_384_HMAC           0x00004017UL
+#define CKM_BLAKE2B_384_HMAC_GENERAL   0x00004018UL
+#define CKM_BLAKE2B_384_KEY_DERIVE     0x00004019UL
+#define CKM_BLAKE2B_384_KEY_GEN        0x0000401aUL
+#define CKM_BLAKE2B_512                0x0000401bUL
+#define CKM_BLAKE2B_512_HMAC           0x0000401cUL
+#define CKM_BLAKE2B_512_HMAC_GENERAL   0x0000401dUL
+#define CKM_BLAKE2B_512_KEY_DERIVE     0x0000401eUL
+#define CKM_BLAKE2B_512_KEY_GEN        0x0000401fUL
+#define CKM_SALSA20                    0x00004020UL
+#define CKM_CHACHA20_POLY1305          0x00004021UL
+#define CKM_SALSA20_POLY1305           0x00004022UL
+#define CKM_X3DH_INITIALIZE            0x00004023UL
+#define CKM_X3DH_RESPOND               0x00004024UL
+#define CKM_X2RATCHET_INITIALIZE       0x00004025UL
+#define CKM_X2RATCHET_RESPOND          0x00004026UL
+#define CKM_X2RATCHET_ENCRYPT          0x00004027UL
+#define CKM_X2RATCHET_DECRYPT          0x00004028UL
+#define CKM_XEDDSA                     0x00004029UL
+#define CKM_HKDF_DERIVE                0x0000402aUL
+#define CKM_HKDF_DATA                  0x0000402bUL
+#define CKM_HKDF_KEY_GEN               0x0000402cUL
+#define CKM_SALSA20_KEY_GEN            0x0000402dUL
+
+#define CKM_ECDSA_SHA3_224             0x00001047UL
+#define CKM_ECDSA_SHA3_256             0x00001048UL
+#define CKM_ECDSA_SHA3_384             0x00001049UL
+#define CKM_ECDSA_SHA3_512             0x0000104aUL
+#define CKM_EC_EDWARDS_KEY_PAIR_GEN    0x00001055UL
+#define CKM_EC_MONTGOMERY_KEY_PAIR_GEN 0x00001056UL
 #define CKM_EDDSA                      0x00001057UL
+#define CKM_SP800_108_COUNTER_KDF      0x000003acUL
+#define CKM_SP800_108_FEEDBACK_KDF     0x000003adUL
+#define CKM_SP800_108_DOUBLE_PIPELINE_KDF 0x000003aeUL
+
+#define CKM_IKE2_PRF_PLUS_DERIVE       0x0000402eUL
+#define CKM_IKE_PRF_DERIVE             0x0000402fUL
+#define CKM_IKE1_PRF_DERIVE            0x00004030UL
+#define CKM_IKE1_EXTENDED_DERIVE       0x00004031UL
+#define CKM_HSS_KEY_PAIR_GEN           0x00004032UL
+#define CKM_HSS                        0x00004033UL
+
 
 #define CKM_VENDOR_DEFINED             0x80000000UL
 
@@ -1011,6 +1179,14 @@ typedef struct CK_MECHANISM_INFO {
 #define CKF_HW                 0x00000001UL  /* performed by HW */
 
 /* Specify whether or not a mechanism can be used for a particular task */
+#define CKF_MESSAGE_ENCRYPT    0x00000002UL
+#define CKF_MESSAGE_DECRYPT    0x00000004UL
+#define CKF_MESSAGE_SIGN       0x00000008UL
+#define CKF_MESSAGE_VERIFY     0x00000010UL
+#define CKF_MULTI_MESSAGE      0x00000020UL
+#define CKF_MULTI_MESSGE       CKF_MULTI_MESSAGE
+#define CKF_FIND_OBJECTS       0x00000040UL
+
 #define CKF_ENCRYPT            0x00000100UL
 #define CKF_DECRYPT            0x00000200UL
 #define CKF_DIGEST             0x00000400UL
@@ -1030,9 +1206,11 @@ typedef struct CK_MECHANISM_INFO {
 #define CKF_EC_F_P             0x00100000UL
 #define CKF_EC_F_2M            0x00200000UL
 #define CKF_EC_ECPARAMETERS    0x00400000UL
-#define CKF_EC_NAMEDCURVE      0x00800000UL
+#define CKF_EC_OID             0x00800000UL
+#define CKF_EC_NAMEDCURVE      CKF_EC_OID   /* deprecated since PKCS#11 3.00 */
 #define CKF_EC_UNCOMPRESS      0x01000000UL
 #define CKF_EC_COMPRESS        0x02000000UL
+#define CKF_EC_CURVENAME       0x04000000UL
 
 #define CKF_EXTENSION          0x80000000UL
 
@@ -1070,6 +1248,7 @@ typedef CK_ULONG          CK_RV;
 #define CKR_DEVICE_REMOVED                    0x00000032UL
 #define CKR_ENCRYPTED_DATA_INVALID            0x00000040UL
 #define CKR_ENCRYPTED_DATA_LEN_RANGE          0x00000041UL
+#define CKR_AEAD_DECRYPT_FAILED               0x00000042UL
 #define CKR_FUNCTION_CANCELED                 0x00000050UL
 #define CKR_FUNCTION_NOT_PARALLEL             0x00000051UL
 
@@ -1162,6 +1341,9 @@ typedef CK_ULONG          CK_RV;
 #define CKR_PUBLIC_KEY_INVALID                0x000001B9UL
 
 #define CKR_FUNCTION_REJECTED                 0x00000200UL
+#define CKR_TOKEN_RESOURCE_EXCEEDED           0x00000201UL
+#define CKR_OPERATION_CANCEL_FAILED           0x00000202UL
+#define CKR_KEY_EXHAUSTED                     0x00000203UL
 
 #define CKR_VENDOR_DEFINED                    0x80000000UL
 
@@ -1179,10 +1361,24 @@ typedef CK_CALLBACK_FUNCTION(CK_RV, CK_NOTIFY)(
  * Cryptoki functions
  */
 typedef struct CK_FUNCTION_LIST CK_FUNCTION_LIST;
+typedef struct CK_FUNCTION_LIST_3_0 CK_FUNCTION_LIST_3_0;
 
 typedef CK_FUNCTION_LIST CK_PTR CK_FUNCTION_LIST_PTR;
+typedef CK_FUNCTION_LIST_3_0 CK_PTR CK_FUNCTION_LIST_3_0_PTR;
 
 typedef CK_FUNCTION_LIST_PTR CK_PTR CK_FUNCTION_LIST_PTR_PTR;
+typedef CK_FUNCTION_LIST_3_0_PTR CK_PTR CK_FUNCTION_LIST_3_0_PTR_PTR;
+
+typedef struct CK_INTERFACE {
+      CK_CHAR     *pInterfaceName;
+      CK_VOID_PTR pFunctionList;
+      CK_FLAGS    flags;
+} CK_INTERFACE;
+
+typedef CK_INTERFACE CK_PTR CK_INTERFACE_PTR;
+typedef CK_INTERFACE_PTR CK_PTR CK_INTERFACE_PTR_PTR;
+
+#define CKF_END_OF_MESSAGE   0x00000001UL
 
 
 /* CK_CREATEMUTEX is an application callback for creating a
@@ -1214,6 +1410,8 @@ typedef CK_CALLBACK_FUNCTION(CK_RV, CK_UNLOCKMUTEX)(
   CK_VOID_PTR pMutex  /* pointer to mutex */
 );
 
+/* Get functionlist flags */
+#define CKF_INTERFACE_FORK_SAFE  0x00000001UL
 
 /* CK_C_INITIALIZE_ARGS provides the optional arguments to
  * C_Initialize
@@ -1236,6 +1434,7 @@ typedef struct CK_C_INITIALIZE_ARGS {
 typedef CK_C_INITIALIZE_ARGS CK_PTR CK_C_INITIALIZE_ARGS_PTR;
 
 
+
 /* additional flags for parameters to functions */
 
 /* CKF_DONT_BLOCK is for the function C_WaitForSlotEvent */
@@ -1256,6 +1455,11 @@ typedef CK_RSA_PKCS_MGF_TYPE CK_PTR CK_RSA_PKCS_MGF_TYPE_PTR;
 #define CKG_MGF1_SHA384       0x00000003UL
 #define CKG_MGF1_SHA512       0x00000004UL
 #define CKG_MGF1_SHA224       0x00000005UL
+#define CKG_MGF1_SHA3_224     0x00000006UL
+#define CKG_MGF1_SHA3_256     0x00000007UL
+#define CKG_MGF1_SHA3_384     0x00000008UL
+#define CKG_MGF1_SHA3_512     0x00000009UL
+
 
 /* CK_RSA_PKCS_OAEP_SOURCE_TYPE  is used to indicate the source
  * of the encoding parameter when formatting a message block
@@ -1293,6 +1497,7 @@ typedef struct CK_RSA_PKCS_PSS_PARAMS {
 typedef CK_RSA_PKCS_PSS_PARAMS CK_PTR CK_RSA_PKCS_PSS_PARAMS_PTR;
 
 typedef CK_ULONG CK_EC_KDF_TYPE;
+typedef CK_EC_KDF_TYPE CK_PTR CK_EC_KDF_TYPE_PTR;
 
 /* The following EC Key Derivation Functions are defined */
 #define CKD_NULL                 0x00000001UL
@@ -1306,7 +1511,23 @@ typedef CK_ULONG CK_EC_KDF_TYPE;
 #define CKD_SHA384_KDF           0x00000007UL
 #define CKD_SHA512_KDF           0x00000008UL
 #define CKD_CPDIVERSIFY_KDF      0x00000009UL
-
+#define CKD_SHA3_224_KDF         0x0000000AUL
+#define CKD_SHA3_256_KDF         0x0000000BUL
+#define CKD_SHA3_384_KDF         0x0000000CUL
+#define CKD_SHA3_512_KDF         0x0000000DUL
+#define CKD_SHA1_KDF_SP800       0x0000000EUL
+#define CKD_SHA224_KDF_SP800     0x0000000FUL
+#define CKD_SHA256_KDF_SP800     0x00000010UL
+#define CKD_SHA384_KDF_SP800     0x00000011UL
+#define CKD_SHA512_KDF_SP800     0x00000012UL
+#define CKD_SHA3_224_KDF_SP800   0x00000013UL
+#define CKD_SHA3_256_KDF_SP800   0x00000014UL
+#define CKD_SHA3_384_KDF_SP800   0x00000015UL
+#define CKD_SHA3_512_KDF_SP800   0x00000016UL
+#define CKD_BLAKE2B_160_KDF      0x00000017UL
+#define CKD_BLAKE2B_256_KDF      0x00000018UL
+#define CKD_BLAKE2B_384_KDF      0x00000019UL
+#define CKD_BLAKE2B_512_KDF      0x0000001aUL
 
 /* CK_ECDH1_DERIVE_PARAMS provides the parameters to the
  * CKM_ECDH1_DERIVE and CKM_ECDH1_COFACTOR_DERIVE mechanisms,
@@ -1848,6 +2069,24 @@ typedef struct CK_GCM_PARAMS {
 
 typedef CK_GCM_PARAMS CK_PTR CK_GCM_PARAMS_PTR;
 
+typedef CK_ULONG CK_GENERATOR_FUNCTION;
+#define CKG_NO_GENERATE      0x00000000UL
+#define CKG_GENERATE         0x00000001UL
+#define CKG_GENERATE_COUNTER 0x00000002UL
+#define CKG_GENERATE_RANDOM  0x00000003UL
+#define CKG_GENERATE_COUNTER_XOR 0x00000004UL
+
+typedef struct CK_GCM_MESSAGE_PARAMS {
+    CK_BYTE_PTR       pIv;
+    CK_ULONG          ulIvLen;
+    CK_ULONG          ulIvFixedBits;
+    CK_GENERATOR_FUNCTION ivGenerator;
+    CK_BYTE_PTR       pTag;
+    CK_ULONG          ulTagBits;
+} CK_GCM_MESSAGE_PARAMS;
+
+typedef CK_GCM_MESSAGE_PARAMS CK_PTR CK_GCM_MESSAGE_PARAMS_PTR;
+
 typedef struct CK_CCM_PARAMS {
     CK_ULONG          ulDataLen;
     CK_BYTE_PTR       pNonce;
@@ -1858,6 +2097,18 @@ typedef struct CK_CCM_PARAMS {
 } CK_CCM_PARAMS;
 
 typedef CK_CCM_PARAMS CK_PTR CK_CCM_PARAMS_PTR;
+
+typedef struct CK_CCM_MESSAGE_PARAMS {
+    CK_ULONG          ulDataLen; /*plaintext or ciphertext*/
+    CK_BYTE_PTR       pNonce;
+    CK_ULONG          ulNonceLen;
+    CK_ULONG          ulNonceFixedBits;
+    CK_GENERATOR_FUNCTION nonceGenerator;
+    CK_BYTE_PTR       pMAC;
+    CK_ULONG          ulMACLen;
+} CK_CCM_MESSAGE_PARAMS;
+
+typedef CK_CCM_MESSAGE_PARAMS CK_PTR CK_CCM_MESSAGE_PARAMS_PTR;
 
 /* Deprecated. Use CK_GCM_PARAMS */
 typedef struct CK_AES_GCM_PARAMS {
@@ -2006,5 +2257,266 @@ typedef struct CK_SEED_CBC_ENCRYPT_DATA_PARAMS {
 typedef CK_SEED_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
                                         CK_SEED_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
-#endif /* _PKCS11T_H_ */
+/*
+ * New PKCS 11 v3.0 data structures.
+ */
 
+typedef CK_ULONG CK_PROFILE_ID;
+typedef CK_PROFILE_ID CK_PTR CK_PROFILE_ID_PTR;
+
+/* Typedefs for Flexible KDF */
+typedef CK_ULONG CK_PRF_DATA_TYPE;
+typedef CK_MECHANISM_TYPE CK_SP800_108_PRF_TYPE;
+#define CK_SP800_108_ITERATION_VARIABLE 0x00000001UL
+#define CK_SP800_108_OPTIONAL_COUNTER   0x00000002UL
+#define CK_SP800_108_DKM_LENGTH         0x00000003UL
+#define CK_SP800_108_BYTE_ARRAY         0x00000004UL
+#define CK_SP800_108_COUNTER            CK_SP800_108_OPTIONAL_COUNTER
+
+typedef struct CK_PRF_DATA_PARAM
+{
+   CK_PRF_DATA_TYPE    type;
+   CK_VOID_PTR         pValue;
+   CK_ULONG            ulValueLen;
+} CK_PRF_DATA_PARAM;
+
+typedef CK_PRF_DATA_PARAM CK_PTR CK_PRF_DATA_PARAM_PTR;
+
+
+typedef struct CK_SP800_108_COUNTER_FORMAT
+{ 
+   CK_BBOOL           bLittleEndian;
+   CK_ULONG		ulWidthInBits;
+} CK_SP800_108_COUNTER_FORMAT;
+
+typedef CK_SP800_108_COUNTER_FORMAT CK_PTR CK_SP800_108_COUNTER_FORMAT_PTR;
+
+typedef CK_ULONG CK_SP800_108_DKM_LENGTH_METHOD;
+#define CK_SP800_108_DKM_LENGTH_SUM_OF_KEYS     0x00000001UL
+#define CK_SP800_108_DKM_LENGTH_SUM_OF_SEGMENTS 0x00000002UL
+
+typedef struct CK_SP800_108_DKM_LENGTH_FORMAT
+{ 
+   CK_SP800_108_DKM_LENGTH_METHOD  dkmLengthMethod;
+   CK_BBOOL                        bLittleEndian;
+   CK_ULONG		             ulWidthInBits;
+} CK_SP800_108_DKM_LENGTH_FORMAT;
+
+typedef CK_SP800_108_DKM_LENGTH_FORMAT \
+                                CK_PTR CK_SP800_108_DKM_LENGTH_FORMAT_PTR;
+
+typedef struct CK_DERIVED_KEY
+{
+   CK_ATTRIBUTE_PTR     pTemplate;
+   CK_ULONG             ulAttributeCount;
+   CK_OBJECT_HANDLE_PTR phKey;
+} CK_DERIVED_KEY;
+
+typedef CK_DERIVED_KEY CK_PTR CK_DERIVED_KEY_PTR;
+
+typedef struct CK_SP800_108_KDF_PARAMS
+{
+   CK_SP800_108_PRF_TYPE prfType;
+   CK_ULONG               ulNumberOfDataParams;
+   CK_PRF_DATA_PARAM_PTR  pDataParams;
+   CK_ULONG             ulAdditionalDerivedKeys;
+   CK_DERIVED_KEY_PTR   pAdditionalDerivedKeys;
+} CK_SP800_108_KDF_PARAMS;
+
+typedef CK_SP800_108_KDF_PARAMS CK_PTR CK_SP800_108_KDF_PARAMS_PTR;
+
+typedef struct CK_SP800_108_FEEDBACK_KDF_PARAMS
+{
+   CK_SP800_108_PRF_TYPE prfType;
+   CK_ULONG               ulNumberOfDataParams;
+   CK_PRF_DATA_PARAM_PTR  pDataParams;
+   CK_ULONG               ulIVLen;
+   CK_BYTE_PTR            pIV;
+   CK_ULONG             ulAdditionalDerivedKeys;
+   CK_DERIVED_KEY_PTR   pAdditionalDerivedKeys;
+} CK_SP800_108_FEEDBACK_KDF_PARAMS;
+
+typedef CK_SP800_108_FEEDBACK_KDF_PARAMS \
+                               CK_PTR CK_SP800_108_FEEDBACK_KDF_PARAMS_PTR;
+
+/* EDDSA */
+typedef struct CK_EDDSA_PARAMS {
+	CK_BBOOL phFlag;
+	CK_ULONG ulContextDataLen;
+	CK_BYTE_PTR pContextData;
+} CK_EDDSA_PARAMS;
+
+typedef CK_EDDSA_PARAMS CK_PTR CK_EDDSA_PARAMS_PTR;
+
+/* Extended ChaCha20/Salsa20 support*/
+typedef struct CK_CHACHA20_PARAMS {
+	CK_BYTE_PTR	pBlockCounter;
+	CK_ULONG	blockCounterBits;
+	CK_BYTE_PTR	pNonce;
+	CK_ULONG	ulNonceBits;
+} CK_CHACHA20_PARAMS;
+
+typedef CK_CHACHA20_PARAMS CK_PTR CK_CHACHA20_PARAMS_PTR;
+
+typedef struct CK_SALSA20_PARAMS {
+	CK_BYTE_PTR	pBlockCounter;
+	CK_BYTE_PTR	pNonce;
+	CK_ULONG	ulNonceBits;
+} CK_SALSA20_PARAMS;
+typedef CK_SALSA20_PARAMS CK_PTR CK_SALSA20_PARAMS_PTR;
+
+typedef struct CK_SALSA20_CHACHA20_POLY1305_PARAMS {
+  CK_BYTE_PTR	pNonce;
+  CK_ULONG	ulNonceLen;
+  CK_BYTE_PTR pAAD;
+  CK_ULONG ulAADLen;
+} CK_SALSA20_CHACHA20_POLY1305_PARAMS;
+
+typedef CK_SALSA20_CHACHA20_POLY1305_PARAMS \
+                                CK_PTR CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR;
+
+typedef struct CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS {
+  CK_BYTE_PTR	pNonce;
+  CK_ULONG	ulNonceLen;
+  CK_BYTE_PTR pTag;
+} CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS;
+
+typedef CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS \
+			CK_PTR CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS_PTR;
+
+typedef CK_ULONG CK_X3DH_KDF_TYPE;
+typedef CK_X3DH_KDF_TYPE CK_PTR CK_X3DH_KDF_TYPE_PTR;
+
+/* X3dh, ratchet */
+typedef struct CK_X3DH_INITIATE_PARAMS {
+	CK_X3DH_KDF_TYPE kdf;
+	CK_OBJECT_HANDLE pPeer_identity;
+	CK_OBJECT_HANDLE pPeer_prekey;
+	CK_BYTE_PTR pPrekey_signature;
+	CK_BYTE_PTR pOnetime_key;
+	CK_OBJECT_HANDLE pOwn_identity;
+	CK_OBJECT_HANDLE pOwn_ephemeral;
+} CK_X3DH_INITIATE_PARAMS;
+
+typedef struct CK_X3DH_RESPOND_PARAMS {
+	CK_X3DH_KDF_TYPE kdf;
+	CK_BYTE_PTR pIdentity_id;
+	CK_BYTE_PTR pPrekey_id;
+	CK_BYTE_PTR pOnetime_id;
+	CK_OBJECT_HANDLE pInitiator_identity;
+	CK_BYTE_PTR pInitiator_ephemeral;
+} CK_X3DH_RESPOND_PARAMS;
+
+typedef CK_ULONG CK_X2RATCHET_KDF_TYPE;
+typedef CK_X2RATCHET_KDF_TYPE CK_PTR CK_X2RATCHET_KDF_TYPE_PTR;
+
+typedef struct CK_X2RATCHET_INITIALIZE_PARAMS {
+	CK_BYTE_PTR 		sk;
+	CK_OBJECT_HANDLE	peer_public_prekey;
+	CK_OBJECT_HANDLE	peer_public_identity;
+	CK_OBJECT_HANDLE	own_public_identity;
+	CK_BBOOL 		bEncryptedHeader;
+	CK_ULONG 		eCurve;
+	CK_MECHANISM_TYPE 	aeadMechanism;
+	CK_X2RATCHET_KDF_TYPE 	kdfMechanism;
+} CK_X2RATCHET_INITIALIZE_PARAMS;
+
+typedef CK_X2RATCHET_INITIALIZE_PARAMS \
+                              CK_PTR CK_X2RATCHET_INITIALIZE_PARAMS_PTR;
+
+typedef struct CK_X2RATCHET_RESPOND_PARAMS {
+	CK_BYTE_PTR 			sk;
+	CK_OBJECT_HANDLE		own_prekey;
+	CK_OBJECT_HANDLE		initiator_identity;
+	CK_OBJECT_HANDLE		own_public_identity;
+	CK_BBOOL 			bEncryptedHeader;
+	CK_ULONG 			eCurve;
+	CK_MECHANISM_TYPE 		aeadMechanism;
+	CK_X2RATCHET_KDF_TYPE 	kdfMechanism;
+} CK_X2RATCHET_RESPOND_PARAMS;
+typedef CK_X2RATCHET_RESPOND_PARAMS \
+				CK_PTR CK_X2RATCHET_RESPOND_PARAMS_PTR;
+
+typedef CK_ULONG CK_XEDDSA_HASH_TYPE;
+typedef CK_XEDDSA_HASH_TYPE CK_PTR CK_XEDDSA_HASH_TYPE_PTR;
+
+/* XEDDSA */
+typedef struct CK_XEDDSA_PARAMS {
+	CK_XEDDSA_HASH_TYPE hash;
+} CK_XEDDSA_PARAMS;
+typedef CK_XEDDSA_PARAMS CK_PTR CK_XEDDSA_PARAMS_PTR;
+
+/* HKDF params */
+typedef struct CK_HKDF_PARAMS {
+   CK_BBOOL bExtract;
+   CK_BBOOL bExpand;
+   CK_MECHANISM_TYPE prfHashMechanism;
+   CK_ULONG ulSaltType;
+   CK_BYTE_PTR pSalt;
+   CK_ULONG ulSaltLen;
+   CK_OBJECT_HANDLE hSaltKey;
+   CK_BYTE_PTR pInfo;
+   CK_ULONG ulInfoLen;
+} CK_HKDF_PARAMS;
+typedef CK_HKDF_PARAMS CK_PTR CK_HKDF_PARAMS_PTR;
+
+#define CKF_HKDF_SALT_NULL   0x00000001UL
+#define CKF_HKDF_SALT_DATA   0x00000002UL
+#define CKF_HKDF_SALT_KEY    0x00000004UL
+
+/* HSS */
+typedef CK_ULONG                   CK_HSS_LEVELS;
+typedef CK_ULONG                   CK_LMS_TYPE;
+typedef CK_ULONG                   CK_LMOTS_TYPE;
+
+typedef struct specifiedParams {
+  CK_HSS_LEVELS levels;
+  CK_LMS_TYPE lm_type[8];
+  CK_LMOTS_TYPE lm_ots_type[8];
+} specifiedParams;
+
+/* IKE Params */
+typedef struct CK_IKE2_PRF_PLUS_DERIVE_PARAMS {
+  CK_MECHANISM_TYPE prfMechanism;
+  CK_BBOOL      bHasSeedKey;
+  CK_OBJECT_HANDLE hSeedKey;
+  CK_BYTE_PTR pSeedData;
+  CK_ULONG    ulSeedDataLen;
+} CK_IKE2_PRF_PLUS_DERIVE_PARAMS;
+typedef CK_IKE2_PRF_PLUS_DERIVE_PARAMS CK_PTR CK_IKE2_PRF_PLUS_DERIVE_PARAMS_PTR;
+
+typedef struct CK_IKE_PRF_DERIVE_PARAMS {
+  CK_MECHANISM_TYPE prfMechanism;
+  CK_BBOOL bDataAsKey;
+  CK_BBOOL bRekey;
+  CK_BYTE_PTR pNi;
+  CK_ULONG    ulNiLen;
+  CK_BYTE_PTR pNr;
+  CK_ULONG    ulNrLen;
+  CK_OBJECT_HANDLE hNewKey;
+} CK_IKE_PRF_DERIVE_PARAMS;
+typedef CK_IKE_PRF_DERIVE_PARAMS CK_PTR CK_IKE_PRF_DERIVE_PARAMS_PTR;
+
+typedef struct CK_IKE1_PRF_DERIVE_PARAMS {
+  CK_MECHANISM_TYPE prfMechanism;
+  CK_BBOOL bHasPrevKey;
+  CK_OBJECT_HANDLE hKeygxy;
+  CK_OBJECT_HANDLE hPrevKey;
+  CK_BYTE_PTR pCKYi;
+  CK_ULONG    ulCKYiLen;
+  CK_BYTE_PTR pCKYr;
+  CK_ULONG    ulCKYrLen;
+  CK_BYTE     keyNumber;
+} CK_IKE1_PRF_DERIVE_PARAMS;
+typedef CK_IKE1_PRF_DERIVE_PARAMS CK_PTR CK_IKE1_PRF_DERIVE_PARAMS_PTR;
+
+typedef struct CK_IKE1_EXTENDED_DERIVE_PARAMS {
+    CK_MECHANISM_TYPE prfMechanism;
+    CK_BBOOL bHasKeygxy;
+    CK_OBJECT_HANDLE hKeygxy;
+    CK_BYTE_PTR pExtraData;
+    CK_ULONG ulExtraDataLen;
+} CK_IKE1_EXTENDED_DERIVE_PARAMS;
+typedef CK_IKE1_EXTENDED_DERIVE_PARAMS CK_PTR CK_IKE1_EXTENDED_DERIVE_PARAMS_PTR;
+
+#endif /* _PKCS11T_H_ */

--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -16,6 +16,7 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Free
 
 IF UNAME_SYSNAME == "Windows":
     from . cimport _mswin as mswin
+    from cpython cimport PyUnicode_GetLength, PyUnicode_AsWideCharString, wchar_t
 ELSE:
     from posix cimport dlfcn
 
@@ -1465,7 +1466,9 @@ cdef class lib:
         cdef C_GetFunctionList_ptr C_GetFunctionList
 
         IF UNAME_SYSNAME == "Windows":
-            self._handle = mswin.LoadLibraryW(so)
+            so_length = PyUnicode_GetLength(so)
+            cdef const wchar_t* so_as_wchar_str = PyUnicode_AsWideCharString(so, &so_length)
+            self._handle = mswin.LoadLibraryW(so_as_wchar_str)
             if self._handle == NULL:
                 raise RuntimeError("Cannot open library at {}: {}".format(so, mswin.winerror(so)))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools",
+            "wheel",
+            "cython",
+            "asn1crypto",
+            "cached-property"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "python-pkcs11"
+version = "0.8.0"
+description = "PKCS#11 (Cryptoki) support for Python"
+authors = [
+    {name = "Danielle Madeley", email = "danielle@madeley.id.au"}
+]
+readme = "README.rst"
+requires-python = ">=3.9"
+license = {file = "LICENSE"}
+classifiers = ["License :: OSI Approved :: MIT License",
+               "Programming Language :: Python :: 3",
+               "Programming Language :: Python :: 3.9",
+               "Programming Language :: Python :: 3.10",
+               "Programming Language :: Python :: 3.11",
+               "Programming Language :: Python :: 3.12",
+               "Development Status :: 5 - Production/Stable",
+               "Intended Audience :: Developers",
+               "Operating System :: OS Independent",
+               "Topic :: Security :: Cryptography",
+               "Topic :: Software Development :: Libraries :: Python Modules",
+               "Topic :: System :: Hardware :: Hardware Drivers",
+               "Topic :: System :: Hardware :: Hardware Drivers :: Smartcard",
+               "Topic :: System :: Hardware :: Hardware Drivers :: Token"]
+
+[project.urls]
+homepage = "https://github.com/pyauth/python-pkcs11"
+"Bug Tracker" = "https://github.com/pyauth/python-pkcs11/issues"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 aenum==2.0.7 ; python_version < "3.6"
-asn1crypto==1.4.0
+asn1crypto==1.5.0
 cached-property==1.5.2

--- a/setup.py
+++ b/setup.py
@@ -1,61 +1,50 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 """
-setup.py
+Installation file. 
 """
 
-from setuptools import setup, find_packages
-from setuptools.extension import Extension
-import platform
+import sys
 
-# if compiling using MSVC, we need to link against user32 library
-if platform.system() == 'Windows':
-    libraries = ['user32',]
-else:
-    libraries = []
+from setuptools import Extension, find_packages, setup
 
-if __name__ == '__main__':
-    with \
-            open('requirements.in') as requirements, \
-            open('README.rst') as readme:
 
-        ext_modules = [
-            Extension('pkcs11._pkcs11',
-                    sources=[
-                        'pkcs11/_pkcs11.pyx',
-                    ],
-                    libraries=libraries,
-            ),
-        ]
+def get_libraries(ls: bool = False) -> tuple|list:
+    """
+    Check the OS and return link to user32 if OS is Windows. 
 
-        setup(
-            name='python-pkcs11',
-            description='PKCS#11 (Cryptoki) support for Python',
-            use_scm_version=True,
-            author='Danielle Madeley',
-            author_email='danielle@madeley.id.au',
-            url='https://github.com/danni/python-pkcs11',
-            long_description=readme.read(),
-            classifiers=[
-                'License :: OSI Approved :: MIT License',
-                'Programming Language :: Python',
-                'Programming Language :: Python :: 3',
-                'Programming Language :: Python :: 3.5',
-                'Programming Language :: Python :: 3.6',
-                'Programming Language :: Python :: 3.7',
-                'Programming Language :: Python :: 3.8',
-                'Topic :: Security :: Cryptography',
-            ],
+    Args:
+        `ls` (bool, optional): Indicate if it should return a list or not. Defaults to False.
 
-            packages=find_packages(exclude=['tests']),
-            include_package_data=True,
-            ext_modules=ext_modules,
-
-            install_requires=requirements.readlines(),
-            setup_requires=[
-                'cython',
-                'setuptools >= 18.0',
-                'setuptools_scm',
-            ],
-
-            test_suite='tests',
-        )
+    Returns:
+        tuple|list: Return user32 in the selected format.
+    """
+    if sys.platform == 'win32':
+        if ls is True:
+            return ['user32', ]
+        else:
+            return ('user32', )
+    else:
+        if ls is True:
+            return []
+        else:
+            return ()
+        
+try:
+    setup(
+        packages=find_packages(exclude=['tests']),
+        include_package_data=True,
+        ext_modules=[Extension(name = "pkcs11._pkcs11",
+                               sources = ["pkcs11/_pkcs11.pyx"],
+                               libraries = get_libraries())],
+        test_suite = 'tests'
+    )
+except:
+    setup(
+        packages=find_packages(exclude=['tests']),
+        include_package_data=True,
+        ext_modules=[Extension(name = "pkcs11._pkcs11",
+                               sources = ["pkcs11/_pkcs11.pyx"],
+                               libraries = get_libraries(ls=True))],
+        test_suite = 'tests'
+    )


### PR DESCRIPTION
This is a new version of the python-pkcs11 package. 

- Updated to PKCS#11 Specification Version 3.1, published by [OASIS Standard](https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/include/pkcs11-v3.1/) on 2023-07-23. 
- Updated `setup.py` to support the new standards by setuptools based on `pyproject.toml`.
- Added `pyproject.toml` to centralize the metadata of the package. 
- Removed deprecated references to `Py_UNICODE*` and replaced them by `wchar_t` as suggested by [PEP-624](https://peps.python.org/pep-0624/#replace-py-unicode-with-wchar-t).
- Added compatibility to Python 3.12 in Windows. 
- Updated requirements version. 
- Bump package version to 0.8.0. 


The package has been tested on new virtual environments using Python 3.12 on Windows 11 with the `asepkcs.dll` (Athena Smartcard System ASE Card). 