### PR TITLE
fix DeprecationWarning in test_ecdh

### DIFF
--- a/docs/opensc.rst
+++ b/docs/opensc.rst
@@ -175,7 +175,7 @@ Smartcard-HSM can generate a shared key via ECDH key exchange.
 
     # Bob generates a keypair, with their public key encoded for
     # interchange
-    bob_priv = ec.generate_private_key(ec.SECP256R1,
+    bob_priv = ec.generate_private_key(ec.SECP256R1(),
                                         default_backend())
     bob_pub = bob_priv.public_key().public_bytes(
         Encoding.DER,

--- a/tests/test_public_key_external.py
+++ b/tests/test_public_key_external.py
@@ -79,7 +79,7 @@ class ExternalPublicKeyTests(TestCase):
 
         # Bob generates a keypair, with their public key encoded for
         # interchange
-        bob_priv = ec.generate_private_key(ec.SECP256R1,
+        bob_priv = ec.generate_private_key(ec.SECP256R1(),
                                            default_backend())
         bob_pub = bob_priv.public_key().public_bytes(
             Encoding.DER,


### PR DESCRIPTION
Also update docs to match

Fixes:
```
 CryptographyDeprecationWarning: Curve argument must be an instance of an EllipticCurve class.
```