### PR TITLE
fix Already initialized error text

### DIFF
--- a/pkcs11/__init__.py
+++ b/pkcs11/__init__.py
@@ -23,7 +23,7 @@ def lib(so):
     if _lib:
         if _so != so:
             raise AlreadyInitialized(  # noqa: F405
-                "Already initialized with %s" % so)
+                "Already initialized with %s" % _so)
         else:
             return _lib
 


### PR DESCRIPTION
Should printout the shared obj we where initialized with, not the one we where trying to (re)initialize with.