### PR TITLE
Correctly handle CK_UNAVAILABLE_INFORMATION

### DIFF
--- a/pkcs11/_pkcs11.pxd
+++ b/pkcs11/_pkcs11.pxd
@@ -151,6 +151,10 @@ cdef extern from '../extern/cryptoki.h':
         CK_TRUE,
         CK_FALSE,
 
+    cdef enum:
+        CK_UNAVAILABLE_INFORMATION,
+        CK_EFFECTIVELY_INFINITE,
+
     cdef enum:  # CK_FLAGS
         CKF_DONT_BLOCK,
         CKF_RW_SESSION,

--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -915,6 +915,8 @@ class Object(types.Object):
         # Find out the attribute size
         with nogil:
             retval = _funclist.C_GetAttributeValue(handle, obj, &template, 1)
+        if retval == CK_UNAVAILABLE_INFORMATION:
+            return None
         assertRV(retval)
 
         if template.ulValueLen == 0:
@@ -927,6 +929,8 @@ class Object(types.Object):
         # Request the value
         with nogil:
             retval = _funclist.C_GetAttributeValue(handle, obj, &template, 1)
+        if retval == CK_UNAVAILABLE_INFORMATION:
+            return None
         assertRV(retval)
 
         return _unpack_attributes(key, value)


### PR DESCRIPTION
The PKCS#11 specification states
```
The constant CK_UNAVAILABLE_INFORMATION is used in the ulValueLen field to denote an invalid or unavailable value. See C_GetAttributeValue for further details.
```

This MR exposes the `CK_UNAVAILABLE_INFORMATION` constant definition (along with `CK_EFFECTIVELY_INFINITE` which is defined next to it, for completeness sake) and checks for that result after calling `C_GetAttributeValue`

This corrects a crash when a PKCS#11 module returns this. I believe this will fix the following issues:
https://github.com/pyauth/python-pkcs11/issues/139
https://github.com/pyauth/python-pkcs11/issues/60

Prior to this change the returned value was being interpreted as an actual size, which resulted in attempting to allocate an array of size -1 which causes an overflow:
```
  File "pkcs11/_pkcs11.pyx", line 726, in pkcs11._pkcs11.Object.__getitem__
  File "pkcs11/_utils.pyx", line 11, in pkcs11._pkcs11.CK_BYTE_buffer
  File "stringsource", line 152, in View.MemoryView.array.__cinit__
OverflowError: Python int too large to convert to C ssize_t
```