### PR TITLE
Fix p11_error() implementation and test it

### DIFF
--- a/extern/load_module.c
+++ b/extern/load_module.c
@@ -17,6 +17,9 @@ static PyObject* p11_error() {
                     NULL);
         PyObject* errmsg = PyUnicode_FromWideChar(msgbuffer, l);
         LocalFree(msgbuffer);
+        if (errmsg == NULL) {
+            Py_RETURN_NONE;
+        }
         return errmsg;
     } else {
         Py_RETURN_NONE;
@@ -61,7 +64,9 @@ static PyObject* p11_error() {
     }
     int len = strlen(error);
     PyObject* result = PyUnicode_DecodeUTF8(error, len, NULL);
-    PyMem_Free(error);
+    if (result == NULL) {
+        Py_RETURN_NONE;
+    }
     return result;
 }
 

--- a/tests/test_slots_and_tokens.py
+++ b/tests/test_slots_and_tokens.py
@@ -14,6 +14,10 @@ class SlotsAndTokensTests(unittest.TestCase):
         self.assertIsNotNone(pkcs11.lib(LIB))
         self.assertIsNotNone(pkcs11.lib(LIB))
 
+    def test_nonexistent_lib(self):
+        with self.assertRaises(RuntimeError):
+            pkcs11.lib("thislibdoesntexist.so")
+
     def test_double_initialise_different_libs(self):
         self.assertIsNotNone(pkcs11.lib(LIB))
         with self.assertRaises(pkcs11.AlreadyInitialized):


### PR DESCRIPTION
I've been doing some experiments to try and remove the limitation that prevents multiple PKCS#11 modules from being loaded at once, and I noticed an unfortunate regression in the library loading handler on POSIX systems. #202 introduced an incorrect call to `PyMem_Free()` in there.

I've fixed it, added a test, and also added some more safeguards against error message decoding issues. We might have push out a bugfix release to address this, though, since it'll in particular cause segfaults when trying to load nonexistent libs.


Sorry about that :/