### PR TITLE
Correctly handle CK_UNAVAILABLE_INFORMATION (2nd attempt)

### DIFF
--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -3,6 +3,7 @@ PKCS#11 Sessions
 """
 
 import pkcs11
+from pkcs11 import Attribute, AttributeSensitive, AttributeTypeInvalid
 
 from . import FIXME, TOKEN_PIN, TOKEN_SO_PIN, Not, Only, TestCase, requires
 
@@ -157,3 +158,17 @@ class SessionTests(TestCase):
             self.assertEqual(len(random), 16)
             # Ensure we didn't get 16 bytes of zeros
             self.assertTrue(all(c != "\0" for c in random))
+
+    def test_attribute_reading_failures(self):
+        with self.token.open(user_pin=TOKEN_PIN) as session:
+            key = session.generate_key(pkcs11.KeyType.AES, 128, label="SAMPLE KEY")
+
+            def try_read_value():
+                return key[Attribute.VALUE]
+
+            self.assertRaises(AttributeSensitive, try_read_value)
+
+            def try_read_irrelevant():
+                return key[Attribute.CERTIFICATE_TYPE]
+
+            self.assertRaises(AttributeTypeInvalid, try_read_irrelevant)


### PR DESCRIPTION
This is a 2nd attempt, because the last rebase in my previous pull request (https://github.com/pyauth/python-pkcs11/pull/200) broke the logic and I missed it. This corrects that oversight.

The PKCS#11 specification states
```
The constant CK_UNAVAILABLE_INFORMATION is used in the ulValueLen field to denote an invalid or unavailable value. See C_GetAttributeValue for further details.
```

This MR exposes the `CK_UNAVAILABLE_INFORMATION` constant definition (along with `CK_EFFECTIVELY_INFINITE` which is defined next to it, for completeness sake) and checks for that result after calling `C_GetAttributeValue`

This corrects a crash when a PKCS#11 module returns this. I believe this will fix the following issues:
https://github.com/pyauth/python-pkcs11/issues/139
https://github.com/pyauth/python-pkcs11/issues/60

Prior to this change the returned value was being interpreted as an actual size, which resulted in attempting to allocate an array of size -1 which causes an overflow:
```
  File "pkcs11/_pkcs11.pyx", line 726, in pkcs11._pkcs11.Object.__getitem__
  File "pkcs11/_utils.pyx", line 11, in pkcs11._pkcs11.CK_BYTE_buffer
  File "stringsource", line 152, in View.MemoryView.array.__cinit__
OverflowError: Python int too large to convert to C ssize_t
```