### PR TITLE
Enable opencryptoki in CI

### DIFF
--- a/.github/actions/install-opencryptoki/action.yml
+++ b/.github/actions/install-opencryptoki/action.yml
@@ -1,0 +1,58 @@
+name: install-opencryptoki
+author: Matthias Valvekens
+description: Install opencryptoki and configure an empty token
+inputs:
+  os:
+    description: OS to target
+    required: true
+  token-label:
+    description: Label assigned to the token
+    required: true
+  token-user-pin:
+    description: User PIN to configure on the token
+    required: true
+  token-so-pin:
+    description: Security officer PIN to configure on the token
+    required: true
+outputs:
+  module:
+    description: Path to PKCS#11 module
+    value: ${{ steps.install.outputs.module }}
+runs:
+  using: "composite"
+  steps:
+    - name: Install opencryptoki
+      id: install
+      shell: bash
+      run: |
+        if [[ "${OS_NAME:0:6}" == 'ubuntu' ]]; then
+          sudo apt install libcap-dev libldap-dev
+          git clone https://github.com/opencryptoki/opencryptoki
+          cd opencryptoki
+          ./bootstrap.sh
+          ./configure --prefix=/usr --sysconfdir=/etc \
+            --with-pkcs-group=users \
+            --disable-tpmtok --disable-ccatok --disable-ep11tok --disable-icsftok \
+            --disable-p11sak --disable-pkcstok_migrate --disable-pkcsstats
+          make
+          sudo make install
+          sudo ldconfig
+          echo -e "slot 0\n{\nstdll = libpkcs11_sw.so\ntokversion = 3.12\n}" > /tmp/opencryptoki.conf
+          sudo cp /tmp/opencryptoki.conf /etc/opencryptoki/
+          sudo chown root:root /etc/opencryptoki/opencryptoki.conf
+          echo "module=/usr/lib/opencryptoki/libopencryptoki.so" >> "$GITHUB_OUTPUT"
+        else
+          echo "$OS_NAME is not a supported target system"
+          exit 1
+        fi
+      env:
+        OS_NAME: ${{ inputs.os }}
+    - name: Run opencryptoki daemon
+      shell: bash
+      run: sudo -u pkcsslotd pkcsslotd
+    - name: Initialize token
+      shell: bash
+      run: |
+        echo "${{ inputs.token-label }}" | pkcsconf -I -c 0 -S 87654321
+        pkcsconf -P -c 0 -S 87654321 -n "${{ inputs.token-so-pin }}"
+        pkcsconf -u -c 0 -S "${{ inputs.token-so-pin }}" -n "${{ inputs.token-user-pin }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-
     steps:
       - name: Acquire sources
         uses: actions/checkout@v4
@@ -43,6 +42,16 @@ jobs:
           token-label: ${{ env.PKCS11_TOKEN_LABEL }}
           token-so-pin: ${{ env.PKCS11_TOKEN_SO_PIN }}
           token-user-pin: ${{ env.PKCS11_TOKEN_PIN }}
+      - uses: ./.github/actions/install-opencryptoki
+        # only run opencryptoki tests on ubuntu
+        # (macos and windows don't seem to be supported)
+        if: matrix.os == 'ubuntu-latest'
+        id: opencryptoki
+        with:
+          os: ${{ matrix.os }}
+          token-label: ${{ env.PKCS11_TOKEN_LABEL }}
+          token-so-pin: ${{ env.PKCS11_TOKEN_SO_PIN }}
+          token-user-pin: ${{ env.PKCS11_TOKEN_PIN }}
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
@@ -50,7 +59,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install testing dependencies
         run: uv sync --no-dev --exact --group testing
-      - name: Run tests
+      - name: Run tests with SoftHSM
         run: uv run pytest -v
         env:
           PKCS11_MODULE: ${{ steps.softhsm.outputs.module }}
+      - name: Run tests with opencryptoki
+        if: matrix.os == 'ubuntu-latest'
+        run: uv run pytest -v
+        env:
+          PKCS11_MODULE: ${{ steps.opencryptoki.outputs.module }}
+          # For testing logic around swapping PKCS#11 libs
+          PKCS11_MODULE2: ${{ steps.softhsm.outputs.module }}

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -12,7 +12,7 @@ from pkcs11 import (
 )
 from pkcs11.attributes import AttributeMapper, handle_bool, handle_str
 
-from . import FIXME, TOKEN_PIN, TOKEN_SO_PIN, Not, Only, TestCase, requires
+from . import TOKEN_PIN, TOKEN_SO_PIN, Not, Only, TestCase, requires
 
 
 class SessionTests(TestCase):
@@ -94,7 +94,6 @@ class SessionTests(TestCase):
             self.assertEqual(len(search), 1)
             self.assertEqual(key, search[0])
 
-    @FIXME.opencryptoki
     def test_create_object(self):
         with self.token.open(user_pin=TOKEN_PIN) as session:
             key = session.create_object(

--- a/tests/test_slots_and_tokens.py
+++ b/tests/test_slots_and_tokens.py
@@ -34,8 +34,8 @@ class SlotsAndTokensTests(unittest.TestCase):
         slots1 = lib1.get_slots()
         slots2 = lib2.get_slots()
 
-        self.assertGreater(len(slots1), 0)
-        self.assertGreater(len(slots2), 0)
+        self.assertGreaterEqual(len(slots1), 1)
+        self.assertGreaterEqual(len(slots2), 1)
 
     def test_double_initialise_nonexistent_lib(self):
         self.assertIsNotNone(pkcs11.lib(LIB))
@@ -62,19 +62,19 @@ class SlotsAndTokensTests(unittest.TestCase):
     def test_reinitialize(self):
         lib = pkcs11.lib(LIB)
         slots = lib.get_slots()
-        self.assertGreater(len(slots), 1)
+        self.assertGreaterEqual(len(slots), 1)
 
         lib.reinitialize()
 
         self.assertTrue(lib.initialized)
         lib = pkcs11.lib(LIB)
         slots = lib.get_slots()
-        self.assertGreater(len(slots), 1)
+        self.assertGreaterEqual(len(slots), 1)
 
     def test_finalize(self):
         lib = pkcs11.lib(LIB)
         slots = lib.get_slots()
-        self.assertGreater(len(slots), 1)
+        self.assertGreaterEqual(len(slots), 1)
 
         lib.finalize()
         self.assertFalse(lib.initialized)
@@ -86,7 +86,7 @@ class SlotsAndTokensTests(unittest.TestCase):
         self.assertFalse(lib.initialized)
         lib = pkcs11.lib(LIB)
         slots = lib.get_slots()
-        self.assertGreater(len(slots), 1)
+        self.assertGreaterEqual(len(slots), 1)
 
     def test_unload_reload(self):
         pkcs11.lib(LIB)
@@ -94,7 +94,7 @@ class SlotsAndTokensTests(unittest.TestCase):
 
         lib = pkcs11.lib(LIB)
         slots = lib.get_slots()
-        self.assertGreater(len(slots), 1)
+        self.assertGreaterEqual(len(slots), 1)
 
     def test_get_mechanism_info(self):
         lib = pkcs11.lib(LIB)


### PR DESCRIPTION
In test runs on Linux, run tests against both opencryptoki and SoftHSM.

This uses opencryptoki's software token.