### PR TITLE
Expand ATTRIBUTE_TYPES for GOSTR support.

### DIFF
--- a/pkcs11/attributes.py
+++ b/pkcs11/attributes.py
@@ -89,6 +89,8 @@ ATTRIBUTE_TYPES = {
     Attribute.VERIFY_RECOVER: handle_bool,
     Attribute.WRAP: handle_bool,
     Attribute.WRAP_WITH_TRUSTED: handle_bool,
+    Attribute.GOSTR3410_PARAMS: handle_bytes,
+    Attribute.GOSTR3411_PARAMS: handle_bytes,
 }
 """
 Map of attributes to (serialize, deserialize) functions.


### PR DESCRIPTION
Added support for GOST R 34.10 and GOST R 34.11 parameters
This PR introduces handling for GOST cryptographic parameters in the ATTRIBUTE_TYPES dictionary:
Mapped Attribute.GOSTR3410_PARAMS to handle_bytes
Mapped Attribute.GOSTR3411_PARAMS to handle_bytes

Changes to be committed:
	modified:   pkcs11/attributes.py