### PR TITLE
Vendor defined mechanism in MechanismWithParam

### DIFF
--- a/pkcs11/attributes.py
+++ b/pkcs11/attributes.py
@@ -89,6 +89,8 @@ ATTRIBUTE_TYPES = {
     Attribute.VERIFY_RECOVER: handle_bool,
     Attribute.WRAP: handle_bool,
     Attribute.WRAP_WITH_TRUSTED: handle_bool,
+    Attribute.GOSTR3410_PARAMS: handle_bytes,
+    Attribute.GOSTR3411_PARAMS: handle_bytes,
 }
 """
 Map of attributes to (serialize, deserialize) functions.


### PR DESCRIPTION
Hello,

This pull request introduces minimal changes required for supporting GOSTR mechanisms within the library.
There is a document describing all GOSTR mechanisms. There is a lot of overlap in the NIST implementation, but to ensure compatibility, the constants are chosen from the vendor-defined range (0x80000000 | 0x54321xxx).
I did not add new constants for the GOSTR parameter, but added a check in the MechanismWithParam class for the vendor-defined mechanism and to interpret the mechanism parameters as a set of bytes if the mechanism parameters are used.

The implementation has been successfully tested against two different vendor PKCS#11 libraries supporting GOST algorithms, specifically verifying data signing functionality.
These changes are backward-compatible and do not affect the existing operation of non-vendor-defined mechanisms.